### PR TITLE
兼容php-redis5扩展

### DIFF
--- a/src/Queue/RedisTopicQueue.php
+++ b/src/Queue/RedisTopicQueue.php
@@ -97,7 +97,7 @@ class RedisTopicQueue extends BaseTopicQueue
             return 0;
         }
 
-        return (int) $this->queue->lSize($topic) ?? 0;
+        return (int) $this->queue->lLen($topic) ?? 0;
     }
 
     public function purge($topic)


### PR DESCRIPTION
处理不兼容php-redis5的问题（php-redis5已废弃lSize函数，当使用redis作为队列时，导致swoole:job无法启动）。php-redis废弃详情具体可查看：https://blog.csdn.net/xchenhao/article/details/97251618